### PR TITLE
Fix #15: Remove unused variables and suppress source map warnings

### DIFF
--- a/working-backwards-assistant/README.md
+++ b/working-backwards-assistant/README.md
@@ -25,6 +25,9 @@ This application helps users innovate like Amazon using the Working Backwards me
    ```
 3. Create a `.env` file in the root directory with your AI API keys:
    ```
+   # Suppress source map warnings (optional)
+   GENERATE_SOURCEMAP=false
+   
    REACT_APP_AI_PROVIDER=openai
    REACT_APP_AI_MODEL=gpt-4o-mini
    REACT_APP_AI_API_KEY=your_api_key_here

--- a/working-backwards-assistant/src/components/Layout.tsx
+++ b/working-backwards-assistant/src/components/Layout.tsx
@@ -7,8 +7,6 @@ import {
   Typography,
   Button,
   Container,
-  useMediaQuery,
-  useTheme,
 } from '@mui/material';
 import {
   Home as HomeIcon,
@@ -28,8 +26,6 @@ interface LayoutProps {
 }
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const navigate = useNavigate();
   const location = useLocation();
   const { userProfile, isAdmin, currentUser, loading: authLoading } = useAuth();

--- a/working-backwards-assistant/src/components/ProtectedRoute.tsx
+++ b/working-backwards-assistant/src/components/ProtectedRoute.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Navigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { Box, Typography, Paper, Container, CircularProgress } from '@mui/material';
 

--- a/working-backwards-assistant/src/components/VoiceTranscriber.tsx
+++ b/working-backwards-assistant/src/components/VoiceTranscriber.tsx
@@ -1,9 +1,7 @@
 import React, { useState, useRef } from 'react';
-import { Button, Box, CircularProgress, Typography, IconButton, Paper } from '@mui/material';
+import { Button, Box, CircularProgress, Typography, IconButton } from '@mui/material';
 import MicIcon from '@mui/icons-material/Mic';
 import StopIcon from '@mui/icons-material/Stop';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import DeleteIcon from '@mui/icons-material/Delete';
 
 interface VoiceTranscriberProps {
   onTranscription: (text: string) => void;
@@ -22,7 +20,6 @@ const VoiceTranscriber: React.FC<VoiceTranscriberProps> = ({
 }) => {
   const [isRecording, setIsRecording] = useState(false);
   const [isTranscribing, setIsTranscribing] = useState(false);
-  const [transcription, setTranscription] = useState(currentText);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const audioChunksRef = useRef<Blob[]>([]);
 
@@ -84,7 +81,6 @@ const VoiceTranscriber: React.FC<VoiceTranscriberProps> = ({
       }
       
       const data = await response.json();
-      setTranscription(data.text);
       onTranscription(data.text);
     } catch (error) {
       console.error('Error transcribing audio:', error);
@@ -92,15 +88,6 @@ const VoiceTranscriber: React.FC<VoiceTranscriberProps> = ({
     } finally {
       setIsTranscribing(false);
     }
-  };
-
-  const clearTranscription = () => {
-    setTranscription("");
-    onTranscription("");
-  };
-
-  const useTranscription = () => {
-    onTranscription(transcription);
   };
 
   if (compact) {

--- a/working-backwards-assistant/src/features/dashboard/components/ProcessFilters.tsx
+++ b/working-backwards-assistant/src/features/dashboard/components/ProcessFilters.tsx
@@ -10,8 +10,7 @@ import {
   Select,
   MenuItem,
   Button,
-  Tooltip,
-  SelectChangeEvent
+  Tooltip
 } from '@mui/material';
 import {
   Add as AddIcon,

--- a/working-backwards-assistant/src/features/prfaq/hooks/useAIGeneration.ts
+++ b/working-backwards-assistant/src/features/prfaq/hooks/useAIGeneration.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { FAQ, WorkingBackwardsResponses, PRFAQ as BackendPRFAQ, AIRequest } from '../../../types';
+import { WorkingBackwardsResponses, PRFAQ as BackendPRFAQ, AIRequest } from '../../../types';
 import {
   getAIResponse, 
   getFirstParagraphPrompt,
@@ -15,7 +15,6 @@ import {
   getStakeholderFAQPrompt,
   getSingleCustomerFAQPrompt,
   getSingleStakeholderFAQPrompt,
-  getPRFAQGenerationPrompt,
 } from '../../../services/aiService';
 import { PRFAQState, updatePRFAQTitle, updatePRFAQPressRelease, addCustomerFAQ, addStakeholderFAQ } from '../../../store/prfaqSlice';
 

--- a/working-backwards-assistant/src/features/prfaq/utils/exportUtils.ts
+++ b/working-backwards-assistant/src/features/prfaq/utils/exportUtils.ts
@@ -70,4 +70,5 @@ export const prfaqMapping: PRFAQMapping = {
   },
 };
 
-export default { handleExport, prfaqMapping }; 
+const exportUtils = { handleExport, prfaqMapping };
+export default exportUtils; 

--- a/working-backwards-assistant/src/features/working-backwards/components/WorkingBackwardsForm.tsx
+++ b/working-backwards-assistant/src/features/working-backwards/components/WorkingBackwardsForm.tsx
@@ -10,7 +10,7 @@ import {
   Button,
   Alert
 } from '@mui/material';
-import { Edit, AutoFixHigh } from '@mui/icons-material';
+import { Edit } from '@mui/icons-material';
 import { useRecoilValue } from 'recoil';
 import { skipInitialThoughtsState } from '../../../atoms/skipInitialThoughtsState';
 import { initialThoughtsState } from '../../../atoms/initialThoughtsState';

--- a/working-backwards-assistant/src/features/working-backwards/hooks/useFormState.ts
+++ b/working-backwards-assistant/src/features/working-backwards/hooks/useFormState.ts
@@ -23,7 +23,7 @@ export const useFormState = () => {
   const dispatch = useDispatch();
   const [questionsState, setQuestionsState] = useRecoilState(workingBackwardsQuestionsState);
   const [initialThoughts] = useRecoilState(initialThoughtsState);
-  const [skipInitialThoughts, setSkipInitialThoughts] = useRecoilState(skipInitialThoughtsState);
+  const [skipInitialThoughts] = useRecoilState(skipInitialThoughtsState);
   const [showSummary, setShowSummary] = useRecoilState(showSummaryState);
   
   const [currentStep, setCurrentStep] = useState(0);

--- a/working-backwards-assistant/src/pages/InitialThoughtsPage.tsx
+++ b/working-backwards-assistant/src/pages/InitialThoughtsPage.tsx
@@ -9,11 +9,9 @@ import {
   Typography, 
   Tab, 
   Tabs, 
-  Divider,
   Alert,
   CircularProgress,
   Snackbar,
-  ClickAwayListener
 } from '@mui/material';
 import { useRecoilState } from 'recoil';
 import { useSelector } from 'react-redux';
@@ -26,7 +24,6 @@ import CustomSnackbar from '../components/CustomSnackbar';
 import { processInitialThoughts } from '../utils/aiProcessing';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import SkipNextIcon from '@mui/icons-material/SkipNext';
-import SaveIcon from '@mui/icons-material/Save';
 import { useCurrentProcess } from '../features/working-backwards/contexts/CurrentProcessContext';
 import ClearIcon from '@mui/icons-material/Clear';
 
@@ -56,8 +53,8 @@ function InitialThoughtsPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const [initialThoughts, setInitialThoughts] = useRecoilState(initialThoughtsState);
-  const [workingBackwardsQuestions, setWorkingBackwardsQuestions] = useRecoilState(workingBackwardsQuestionsState);
-  const [skipInitialThoughts, setSkipInitialThoughts] = useRecoilState(skipInitialThoughtsState);
+  const [, setWorkingBackwardsQuestions] = useRecoilState(workingBackwardsQuestionsState);
+  const [, setSkipInitialThoughts] = useRecoilState(skipInitialThoughtsState);
   const prfaq = useSelector((state: RootState) => state.prfaq);
   const [tabValue, setTabValue] = useState(0);
   const [isProcessing, setIsProcessing] = useState(false);

--- a/working-backwards-assistant/src/services/workingBackwardsService.ts
+++ b/working-backwards-assistant/src/services/workingBackwardsService.ts
@@ -8,14 +8,9 @@ import {
   addDoc, 
   updateDoc, 
   deleteDoc, 
-  Timestamp, 
   serverTimestamp, 
-  orderBy,
   onSnapshot,
   writeBatch,
-  runTransaction,
-  DocumentReference,
-  Firestore
 } from 'firebase/firestore';
 import { db } from '../lib/firebase/firebase';
 import { WorkingBackwardsProcess, WorkingBackwardsProcessSummary } from '../types/workingBackwards';


### PR DESCRIPTION
   This PR addresses issue #15 by:

   1. Removing unused variables and imports across multiple files to resolve ESLint warnings
   2. Adding GENERATE_SOURCEMAP=false to suppress source map warnings from react-quill-new
   3. Updating README with information about source map suppression

   All ESLint warnings are now resolved and the development console is clean.